### PR TITLE
Use official config with support for private files.

### DIFF
--- a/drupal.conf
+++ b/drupal.conf
@@ -1,67 +1,91 @@
 server {
-  listen 80;
-  server_name _;
-  root /var/www/html;
+    server_name _;
+    root /var/www/html;
 
-  location ~ \..*/.*\.php$ {
-    return 403;
-  }
-
-  location ~ (^|/)\. {
-    return 403;
-  }
-
-  location / {
-    try_files $uri @rewrite;
-  }
-
-  location @rewrite {
-    rewrite ^ /index.php;
-  }
-
-  location ~ \.php$ {
-    set $no_cache "";
-    if ($request_method !~ ^(GET|HEAD)$) {
-      set $no_cache "1";
-    }        
-
-    if ($no_cache = "1") {
-      #add_header Set-Cookie "_mcnc=1; Max-Age=2; Path=/";
-      #add_header X-Microcachable "0";
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
     }
 
-    if ($http_cookie ~ SESS) {
-      set $no_cache "1";
-    }                
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
 
-    #fastcgi_no_cache $no_cache;
-    #fastcgi_cache_bypass $no_cache;
-    #include microcache_fcgi.conf;
-    #fastcgi_cache microcache;
-    #fastcgi_cache_key $server_name|$request_uri;
-    #fastcgi_cache_valid 404 30m;
-    #fastcgi_cache_valid 200 1s;
-    #fastcgi_max_temp_file_size 1M;
-    #fastcgi_cache_use_stale updating;
-    fastcgi_pass php:9000;        
-    #fastcgi_pass_header Set-Cookie;
-    #fastcgi_pass_header Cookie;
-    #fastcgi_ignore_headers Cache-Control Expires Set-Cookie;
+    # Very rarely should these ever be accessed outside of your lan
+    location ~* \.(txt|log)$ {
+        allow 192.168.0.0/16;
+        deny all;
+    }
 
-    fastcgi_index index.php;
-    include fastcgi_params;
-    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    fastcgi_param PATH_INFO $fastcgi_path_info;
-  }
+    location ~ \..*/.*\.php$ {
+        return 403;
+    }
 
-  # Catch image styles for D7 too.
-  location ~ ^/sites/.*/files/styles/ {
-    try_files $uri @rewrite;
-  }
+    location ~ ^/sites/.*/private/ {
+        return 403;
+    }
 
-  location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
-    expires max;
-    #log_not_found off;
-  }
+    # Allow "Well-Known URIs" as per RFC 5785
+    location ~* ^/.well-known/ {
+        allow all;
+    }
+
+    # Block access to "hidden" files and directories whose names begin with a
+    # period. This includes directories used by version control systems such
+    # as Subversion or Git to store control files.
+    location ~ (^|/)\. {
+        return 403;
+    }
+
+    location / {
+        # try_files $uri @rewrite; # For Drupal <= 6
+        try_files $uri /index.php?$query_string; # For Drupal >= 7
+    }
+
+    location @rewrite {
+        rewrite ^/(.*)$ /index.php?q=$1;
+    }
+
+    # Don't allow direct access to PHP files in the vendor directory.
+    location ~ /vendor/.*\.php$ {
+        deny all;
+        return 404;
+    }
+
+    # In Drupal 8, we must also match new paths where the '.php' appears in the middle,
+    # such as update.php/selection. The rule we use is strict, and only allows this pattern
+    # with the update.php front controller.  This allows legacy path aliases in the form of
+    # blog/index.php/legacy-path to continue to route to Drupal nodes. If you do not have
+    # any paths like that, then you might prefer to use a laxer rule, such as:
+    #   location ~ \.php(/|$) {
+    # The laxer rule will continue to work if Drupal uses this new URL pattern with front
+    # controllers other than update.php in a future release.
+    location ~ '\.php$|^/update.php' {
+        fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
+        #NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_intercept_errors on;
+        fastcgi_pass php:9000;
+    }
+
+    # Fighting with Styles? This little gem is amazing.
+    # location ~ ^/sites/.*/files/imagecache/ { # For Drupal <= 6
+    location ~ ^/sites/.*/files/styles/ { # For Drupal >= 7
+        try_files $uri @rewrite;
+    }
+
+    # Handle private files through Drupal.
+    location ~ ^/system/files/ { # For Drupal >= 7
+        try_files $uri /index.php?$query_string;
+    }
+
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+        expires max;
+        log_not_found off;
+    }
 }
 


### PR DESCRIPTION
Private files are throwing 404. I updated nginx config based on https://www.nginx.com/resources/wiki/start/topics/recipes/drupal/ and added an additional snippet to handle private files (nginxinc/nginx-wiki#267).
