### PR TITLE
Fix unavailable www-data user for alpine, by using the nginx user

### DIFF
--- a/mainline-alpine/Dockerfile
+++ b/mainline-alpine/Dockerfile
@@ -5,5 +5,10 @@ MAINTAINER drupal-docker <info@drupaldocker.org>
 WORKDIR /var/www/html
 VOLUME /var/www/html
 
+# ensure www-data user exists
+RUN set -x \
+	&& addgroup -g 82 -S www-data \
+	&& adduser -u 82 -D -S -G www-data www-data
+
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY drupal.conf /etc/nginx/conf.d/default.conf

--- a/mainline-alpine/Dockerfile
+++ b/mainline-alpine/Dockerfile
@@ -5,10 +5,9 @@ MAINTAINER drupal-docker <info@drupaldocker.org>
 WORKDIR /var/www/html
 VOLUME /var/www/html
 
-# ensure www-data user exists
-RUN set -x \
-	&& addgroup -g 82 -S www-data \
-	&& adduser -u 82 -D -S -G www-data www-data
+# Ensure www-data user exists.
+RUN addgroup -g 82 -S www-data \
+  && adduser -u 82 -D -S -G www-data www-data
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY drupal.conf /etc/nginx/conf.d/default.conf

--- a/stable-alpine/Dockerfile
+++ b/stable-alpine/Dockerfile
@@ -5,5 +5,10 @@ MAINTAINER drupal-docker <info@drupaldocker.org>
 WORKDIR /var/www/html
 VOLUME /var/www/html
 
+# ensure www-data user exists
+RUN set -x \
+	&& addgroup -g 82 -S www-data \
+	&& adduser -u 82 -D -S -G www-data www-data
+
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY drupal.conf /etc/nginx/conf.d/default.conf

--- a/stable-alpine/Dockerfile
+++ b/stable-alpine/Dockerfile
@@ -5,10 +5,9 @@ MAINTAINER drupal-docker <info@drupaldocker.org>
 WORKDIR /var/www/html
 VOLUME /var/www/html
 
-# ensure www-data user exists
-RUN set -x \
-	&& addgroup -g 82 -S www-data \
-	&& adduser -u 82 -D -S -G www-data www-data
+# Ensure www-data user exists.
+RUN addgroup -g 82 -S www-data \
+  && adduser -u 82 -D -S -G www-data www-data
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY drupal.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
When trying to use the alpine tag I am getting this error:
`[emerg] 1#1: getpwnam("www-data") failed in /etc/nginx/nginx.conf:1`

After investingating the main nginx-alpine docker image I found that the nginx user and group are being created, so I changed it to use that instead of `www-data`
