### PR TITLE
Increase client_max_body_size

### DIFF
--- a/mainline/nginx.conf
+++ b/mainline/nginx.conf
@@ -23,6 +23,7 @@ http {
   access_log  /var/log/nginx/access.log  main;
 
   keepalive_timeout  120;
+  client_max_body_size 20m;
 
   include /etc/nginx/conf.d/*.conf;
 }

--- a/stable/nginx.conf
+++ b/stable/nginx.conf
@@ -23,6 +23,7 @@ http {
   access_log  /var/log/nginx/access.log  main;
 
   keepalive_timeout  120;
+  client_max_body_size 20m;
 
   include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
Max body size is 1MB by default. This prevents us from uploading files larger than that and I think that we could increase it to something more sensible. 

It would probably make sense to do the same in PHP images.