### PR TITLE
Increase fastcgi_buffer to avoid 502 Bad Gateway errors.

### DIFF
--- a/stable/drupal.conf
+++ b/stable/drupal.conf
@@ -70,6 +70,11 @@ server {
         fastcgi_param PATH_INFO $fastcgi_path_info;
         fastcgi_intercept_errors on;
         fastcgi_pass php:9000;
+
+        # Added to avoid 502 Bad Gateway errors
+        fastcgi_buffer_size 512k;
+        fastcgi_buffers 16 512k;
+        fastcgi_read_timeout 600;
     }
 
     # Fighting with Styles? This little gem is amazing.


### PR DESCRIPTION
I was having regular 502 errors during development, and got to a solution by following instructions here:

https://medium.com/@richb_/tweaking-nginx-and-php-fpm-configuration-to-fix-502-bad-gateway-errors-and-optimise-performance-on-17465f41fd87